### PR TITLE
fix: charm build broken with charmcraft 4.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
           - .
           - tests/integration/requirer-charm
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v35.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v42.1.0
     with:
       path-to-charm-directory: ${{ matrix.path }}
       charmcraft-snap-revisions: '{"amd64": "7517", "arm64": "7519"}'
@@ -69,7 +69,7 @@ jobs:
       - lint
       - unit-test
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v35.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v42.1.0
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
       architecture: ${{ matrix.architecture }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v35.0.2
     with:
       path-to-charm-directory: ${{ matrix.path }}
+      charmcraft-snap-revisions: '{"amd64": "7517", "arm64": "7519"}'
 
   integration-test:
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Release charm
     needs:
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v35.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v42.1.0
     with:
       track: "1"
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}


### PR DESCRIPTION
charmcraft 4.2 is broken, see https://github.com/canonical/charmcraft/issues/2620

pin charmcraft snap revisions